### PR TITLE
Add support for replacing sys.executable with PIP2NIX_PYTHON_EXECUTAB…

### DIFF
--- a/pip2nix/cli.py
+++ b/pip2nix/cli.py
@@ -69,7 +69,10 @@ def generate(specifiers, **kwargs):
 
     from pip2nix.main import main
     from pip2nix.generate import generate
+    import os
     import sys
+
+    sys.executable = os.environ.get("PIP2NIX_PYTHON_EXECUTABLE") or sys.executable
     generate(config)
 
 


### PR DESCRIPTION
…LE to fix issue where setuptools was not available on Nix installed version [#6]